### PR TITLE
Prevent duplicate recipes from appearing in generated articles

### DIFF
--- a/tools/retrieval.py
+++ b/tools/retrieval.py
@@ -24,13 +24,22 @@ def search_recipes(query, index, id_to_recipe, category=None, tags=None, k=5):
     
     # Get recipes
     results = []
+    seen_recipe_ids = set()
+    recipe_ids = list(id_to_recipe.keys())
     for score, idx in zip(scores[0], indices[0]):
         if idx == -1:  # Invalid index
             continue
-            
-        recipe_id = list(id_to_recipe.keys())[idx]
+
+        if idx >= len(recipe_ids):
+            continue
+
+        recipe_id = recipe_ids[idx]
+
+        if recipe_id in seen_recipe_ids:
+            continue
+
         recipe = id_to_recipe[recipe_id]
-        
+
         # Apply filters
         if category and recipe.get("category", "").lower() != category.lower():
             continue
@@ -40,6 +49,7 @@ def search_recipes(query, index, id_to_recipe, category=None, tags=None, k=5):
                 continue
         
         results.append(recipe)
+        seen_recipe_ids.add(recipe_id)
         if len(results) >= k:
             break
     


### PR DESCRIPTION
## Summary
- prevent the FAISS retrieval layer from returning the same recipe multiple times
- deduplicate recipe inputs before article generation so sections stay unique

## Testing
- python -m compileall tools

------
https://chatgpt.com/codex/tasks/task_e_68e4889ae25083338ebe9382aafb9fa0