### PR TITLE
Improve reliability of WordPress image proxy

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -25,6 +25,16 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 app = Flask(__name__)
 CORS(app, origins=["https://test-for-write.onrender.com", "http://localhost:3000", "http://localhost:3003"])
 
+WORDPRESS_PROXY_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/121.0.0.0 Safari/537.36"
+    ),
+    "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
 # Global variables for cached data
 recipes_cache = None
 faiss_index = None
@@ -445,7 +455,12 @@ def proxy_wordpress_asset():
         return jsonify({'error': 'Invalid url scheme'}), 400
 
     try:
-        upstream_response = requests.get(image_url, stream=True, timeout=15)
+        upstream_response = requests.get(
+            image_url,
+            stream=True,
+            timeout=15,
+            headers=WORDPRESS_PROXY_HEADERS,
+        )
         upstream_response.raise_for_status()
     except requests.RequestException as exc:
         return jsonify({'error': f'Failed to fetch image: {exc}'}), 502

--- a/production_server.py
+++ b/production_server.py
@@ -18,6 +18,16 @@ from urllib.parse import urlparse
 
 app = Flask(__name__)
 
+WORDPRESS_PROXY_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/121.0.0.0 Safari/537.36"
+    ),
+    "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
 # Global variables for pre-computed data
 recipes = None
 index = None
@@ -166,7 +176,12 @@ def proxy_wordpress_asset():
         return jsonify({'error': 'Invalid url scheme'}), 400
 
     try:
-        upstream_response = requests.get(image_url, stream=True, timeout=15)
+        upstream_response = requests.get(
+            image_url,
+            stream=True,
+            timeout=15,
+            headers=WORDPRESS_PROXY_HEADERS,
+        )
         upstream_response.raise_for_status()
     except requests.RequestException as exc:
         return jsonify({'error': f'Failed to fetch image: {exc}'}), 502


### PR DESCRIPTION
## Summary
- add realistic browser-style headers that WordPress image hosts expect
- send the headers for both the cache-building server and production server proxy endpoints

## Testing
- python -m compileall api_server.py production_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e5aa6680ec8333bf0960b4fd9a2cae