### PR TITLE
Allow setting referer header for WordPress proxy

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -462,7 +462,12 @@ def generate_recipe_article():
 
 @app.route('/api/wordpress/proxy', methods=['GET'])
 def proxy_wordpress_asset():
-    """Proxy remote assets (typically images) for WordPress drafts."""
+    """Proxy remote assets (typically images) for WordPress drafts.
+
+    Accepts an optional ``referer`` query parameter that will be forwarded as a
+    ``Referer`` header. This is useful for CDNs that enforce hotlink
+    protection and refuse to serve assets without an expected referrer.
+    """
     image_url = request.args.get('url', '').strip()
 
     if not image_url:
@@ -472,11 +477,19 @@ def proxy_wordpress_asset():
     if parsed.scheme not in ('http', 'https'):
         return jsonify({'error': 'Invalid url scheme'}), 400
 
+    referer = request.args.get('referer', '').strip()
+    request_headers = WORDPRESS_PROXY_HEADERS.copy()
+    if referer:
+        referer_parsed = urlparse(referer)
+        if referer_parsed.scheme in ('http', 'https'):
+            request_headers['Referer'] = referer
+
     try:
         with WORDPRESS_PROXY_SESSION.get(
             image_url,
             stream=True,
             timeout=WORDPRESS_PROXY_TIMEOUT,
+            headers=request_headers,
         ) as upstream_response:
             upstream_response.raise_for_status()
             content = upstream_response.content
@@ -488,6 +501,8 @@ def proxy_wordpress_asset():
             'exception_type': type(exc).__name__,
             'message': str(exc),
         }
+        if referer:
+            error_details['referer'] = referer
 
         response = getattr(exc, 'response', None)
         if response is not None:

--- a/production_server.py
+++ b/production_server.py
@@ -183,7 +183,12 @@ def generate_recipe_article():
 
 @app.route('/api/wordpress/proxy', methods=['GET'])
 def proxy_wordpress_asset():
-    """Proxy remote assets (typically images) for WordPress drafts."""
+    """Proxy remote assets (typically images) for WordPress drafts.
+
+    Accepts an optional ``referer`` query parameter that will be forwarded as a
+    ``Referer`` header. This is useful for CDNs that enforce hotlink
+    protection and refuse to serve assets without an expected referrer.
+    """
     image_url = request.args.get('url', '').strip()
 
     if not image_url:
@@ -193,11 +198,19 @@ def proxy_wordpress_asset():
     if parsed.scheme not in ('http', 'https'):
         return jsonify({'error': 'Invalid url scheme'}), 400
 
+    referer = request.args.get('referer', '').strip()
+    request_headers = WORDPRESS_PROXY_HEADERS.copy()
+    if referer:
+        referer_parsed = urlparse(referer)
+        if referer_parsed.scheme in ('http', 'https'):
+            request_headers['Referer'] = referer
+
     try:
         with WORDPRESS_PROXY_SESSION.get(
             image_url,
             stream=True,
             timeout=WORDPRESS_PROXY_TIMEOUT,
+            headers=request_headers,
         ) as upstream_response:
             upstream_response.raise_for_status()
             content = upstream_response.content
@@ -209,6 +222,8 @@ def proxy_wordpress_asset():
             'exception_type': type(exc).__name__,
             'message': str(exc),
         }
+        if referer:
+            error_details['referer'] = referer
 
         response = getattr(exc, 'response', None)
         if response is not None:


### PR DESCRIPTION
## Summary
- allow the WordPress asset proxy to accept an optional `referer` query parameter and forward it to the upstream request
- include the forwarded referrer value in proxy error details to aid debugging
- document the new behavior in the proxy view docstrings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e97fb09dc4833384d03c6a7bcfd85e