### PR TITLE
Ensure fallback article builders hotlink Airtable imagery

### DIFF
--- a/production_server.py
+++ b/production_server.py
@@ -16,7 +16,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib.parse import urlparse
 
-from tools.image_utils import extract_remote_image_url
+from tools.image_utils import build_remote_image_figure, extract_remote_image_url
 from tools.generator import generate_article as structured_generate_article
 from urllib3.util import Retry
 
@@ -229,18 +229,7 @@ def _fallback_article(query, recipes):
 
         image_url, airtable_field = extract_remote_image_url(recipe)
         if image_url:
-            section.append(
-                '\n'.join(
-                    [
-                        '<figure style="margin: 10px 0; text-align: center;" '
-                        'data-image-hosting="remote" data-image-hotlink="true" '
-                        f'data-image-source-field="{airtable_field or "unknown"}">',
-                        f'<img src="{image_url}" alt="{title}" style="max-width: 100%; height: auto;" loading="lazy" data-original-image-url="{image_url}">',
-                        f'<figcaption style="font-size: 0.9em; color: #666; font-style: italic;">{image_url}</figcaption>',
-                        '</figure>',
-                    ]
-                )
-            )
+            section.append(build_remote_image_figure(title, image_url, airtable_field))
 
         ingredients = recipe.get('ingredients')
         if ingredients:

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, List, Optional, Sequence
 import openai
 
 from config import *
-from .image_utils import build_image_credit, extract_remote_image_url
+from .image_utils import build_remote_image_figure, extract_remote_image_url
 from .prompt_templates import (
     CONCLUSION_TEMPLATE,
     COOKING_TIPS_TEMPLATE,
@@ -20,32 +20,6 @@ from .prompt_templates import (
 SYSTEM_PROMPT = (
     "You are a professional food writer who creates engaging, appetizing content."
 )
-
-
-def _build_image_figure(
-    title: str,
-    image_url: Optional[str],
-    airtable_field: Optional[str],
-) -> str:
-    """Return a ready-to-use HTML figure that hotlinks the remote recipe image."""
-    if not image_url:
-        return ""
-
-    caption = build_image_credit(image_url)
-    source_field = airtable_field or "unknown"
-    return (
-        '\n<figure style="margin: 10px 0; text-align: center;" '
-        'data-image-hosting="remote" '
-        'data-image-hotlink="true" '
-        f'data-image-source-field="{source_field}">'
-        f'\n<img src="{image_url}" alt="{title}" '
-        'width="1280" height="720" '
-        'style="width: 100%; max-width: 1280px; height: auto; border-radius: 8px; object-fit: cover;" '
-        'loading="lazy" '
-        f'data-original-image-url="{image_url}">'
-        f'\n<figcaption style="font-size: 0.9em; color: #666; margin-top: 5px; font-style: italic;">{caption}</figcaption>'
-        '\n</figure>'
-    )
 
 
 def _deduplicate_recipes(recipes_list: Sequence[Dict]) -> List[Dict]:
@@ -172,7 +146,7 @@ class RecipeArticleBuilder:
         )
 
         image_url, airtable_field = extract_remote_image_url(recipe)
-        figure = _build_image_figure(title, image_url, airtable_field)
+        figure = build_remote_image_figure(title, image_url, airtable_field)
 
         if response:
             body = _ensure_paragraphs(response)

--- a/tools/image_utils.py
+++ b/tools/image_utils.py
@@ -91,3 +91,29 @@ def build_image_credit(image_url: str) -> str:
         return "Image credit: Source"
 
     return f"Image credit: {domain}"
+
+
+def build_remote_image_figure(
+    title: str,
+    image_url: Optional[str],
+    airtable_field: Optional[str],
+) -> str:
+    """Return a HTML figure element that hotlinks the remote Airtable image."""
+    if not image_url:
+        return ""
+
+    caption = build_image_credit(image_url)
+    source_field = airtable_field or "unknown"
+    return (
+        '\n<figure style="margin: 10px 0; text-align: center;" '
+        'data-image-hosting="remote" '
+        'data-image-hotlink="true" '
+        f'data-image-source-field="{source_field}">'
+        f'\n<img src="{image_url}" alt="{title}" '
+        'width="1280" height="720" '
+        'style="width: 100%; max-width: 1280px; height: auto; border-radius: 8px; object-fit: cover;" '
+        'loading="lazy" '
+        f'data-original-image-url="{image_url}">'
+        f'\n<figcaption style="font-size: 0.9em; color: #666; margin-top: 5px; font-style: italic;">{caption}</figcaption>'
+        '\n</figure>'
+    )


### PR DESCRIPTION
## Summary
- add a shared helper that renders remote Airtable images as hotlinked figures
- update structured and fallback article builders to rely on the shared helper
- replace the API fallback generator with deterministic HTML that always links Airtable-hosted images

## Testing
- `python -m compileall tools api_server.py production_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68ede29dd37883339183663fe6164e95