### PR TITLE
Refine hotlink-based image publishing flow

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -17,7 +17,11 @@ import time
 import faiss
 from urllib.parse import urlparse
 
-from tools.image_utils import build_remote_image_figure, extract_remote_image_url
+from tools.image_utils import (
+    build_remote_image_figure,
+    collect_image_hotlinks,
+    extract_remote_image_url,
+)
 from flask import Flask, request, jsonify, redirect
 from flask_cors import CORS
 from urllib3.util import Retry
@@ -580,17 +584,7 @@ def generate_recipe_article():
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
 
         # Surface image hotlink information so downstream systems avoid re-hosting.
-        image_hotlinks = []
-        for recipe in top_recipes:
-            image_url, airtable_field = extract_remote_image_url(recipe)
-            if not image_url:
-                continue
-            image_hotlinks.append({
-                'title': recipe.get('title', 'Untitled Recipe'),
-                'image_url': image_url,
-                'airtable_field': airtable_field,
-                'hotlink': True,
-            })
+        image_hotlinks = collect_image_hotlinks(top_recipes)
 
         print("=== Recipe Query Completed Successfully ===")
 

--- a/production_server.py
+++ b/production_server.py
@@ -16,7 +16,11 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib.parse import urlparse
 
-from tools.image_utils import build_remote_image_figure, extract_remote_image_url
+from tools.image_utils import (
+    build_remote_image_figure,
+    collect_image_hotlinks,
+    extract_remote_image_url,
+)
 from tools.generator import generate_article as structured_generate_article
 from urllib3.util import Retry
 
@@ -290,17 +294,7 @@ def generate_recipe_article():
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
 
         # Surface image hotlink information so downstream systems avoid re-hosting.
-        image_hotlinks = []
-        for recipe in top_recipes:
-            image_url, airtable_field = extract_remote_image_url(recipe)
-            if not image_url:
-                continue
-            image_hotlinks.append({
-                'title': recipe.get('title', 'Untitled Recipe'),
-                'image_url': image_url,
-                'airtable_field': airtable_field,
-                'hotlink': True,
-            })
+        image_hotlinks = collect_image_hotlinks(top_recipes)
 
         return jsonify({
             'article': article,

--- a/simple_server.py
+++ b/simple_server.py
@@ -12,7 +12,7 @@ import json
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from tools import airtable_sync, embeddings, vector_store, retrieval, generator
-from tools.image_utils import extract_remote_image_url
+from tools.image_utils import collect_image_hotlinks, extract_remote_image_url
 
 app = Flask(__name__)
 
@@ -129,17 +129,7 @@ def generate_recipe_article():
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
 
         # Surface image hotlink information so downstream systems avoid re-hosting.
-        image_hotlinks = []
-        for recipe in top_recipes:
-            image_url, airtable_field = extract_remote_image_url(recipe)
-            if not image_url:
-                continue
-            image_hotlinks.append({
-                'title': recipe.get('title', 'Untitled Recipe'),
-                'image_url': image_url,
-                'airtable_field': airtable_field,
-                'hotlink': True,
-            })
+        image_hotlinks = collect_image_hotlinks(top_recipes)
 
         return jsonify({
             'article': article,

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -1,4 +1,19 @@
-"""Recipe article generation that preserves original Airtable image links."""
+"""Recipe article generation that preserves original Airtable image links.
+
+Preparing images for publishing now follows a pure hotlink workflow:
+
+1. `extract_remote_image_url` identifies the Airtable field that already holds
+   a publicly reachable asset and returns the untouched URL.
+2. We never download or mirror that asset. The URL is passed straight through
+   to HTML generation so WordPress (or any CMS) can embed it via `<img src>`
+   without touching the media library.
+3. `build_remote_image_figure` wraps the hotlinked URL in a `<figure>` element
+   and annotates it with provenance metadata for easy auditing.
+4. If a recipe has no usable URL we simply omit the figure while still
+   returning the textual section, preventing broken placeholders.
+5. The API layer exposes `image_hotlinks` metadata so automation scripts can
+   set featured images or galleries using the same remote links.
+"""
 
 from __future__ import annotations
 

--- a/tools/image_utils.py
+++ b/tools/image_utils.py
@@ -7,7 +7,7 @@ for downstream HTML generation or validation.
 """
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
 # Fields that Airtable uses to store the original image URL. The order
@@ -117,3 +117,32 @@ def build_remote_image_figure(
         f'\n<figcaption style="font-size: 0.9em; color: #666; margin-top: 5px; font-style: italic;">{caption}</figcaption>'
         '\n</figure>'
     )
+
+
+def collect_image_hotlinks(recipes: Iterable[Dict]) -> List[Dict[str, object]]:
+    """Return a normalized listing of remote image metadata.
+
+    The resulting dictionaries make it trivial for publishing pipelines or
+    WordPress automations to embed remote imagery without downloading it. Each
+    entry includes the remote URL along with the Airtable field that supplied
+    the link so downstream systems can decide how best to hotlink it.
+    """
+
+    hotlinks: List[Dict[str, object]] = []
+
+    for recipe in recipes:
+        image_url, airtable_field = extract_remote_image_url(recipe)
+        if not image_url:
+            continue
+
+        hotlinks.append(
+            {
+                "title": recipe.get("title", "Untitled Recipe"),
+                "image_url": image_url,
+                "airtable_field": airtable_field,
+                "hotlink": True,
+                "record_id": recipe.get("id") or recipe.get("record_id"),
+            }
+        )
+
+    return hotlinks


### PR DESCRIPTION
## Summary
- document the hotlink-only publishing workflow in the recipe generator
- centralize remote image metadata collection so every server surfaces Airtable hotlinks without re-uploading
- keep all API responses aligned on the hotlink data for downstream WordPress automations

## Testing
- python -m compileall tools api_server.py production_server.py simple_server.py

------
https://chatgpt.com/codex/tasks/task_e_68edf15712248333a810913513756736