### PR TITLE
Expose hotlink metadata across servers

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,6 +7,7 @@ Industry standard for enterprise server-to-server AI services.
 import json
 import os
 from tools import retrieval, generator
+from tools.image_utils import collect_image_hotlinks
 
 # Pre-computed data (loaded once per Lambda instance)
 recipes = None
@@ -80,6 +81,8 @@ def lambda_handler(event, context):
         # Extract sources
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
         
+        image_hotlinks = collect_image_hotlinks(top_recipes)
+
         return {
             'statusCode': 200,
             'headers': {
@@ -90,7 +93,8 @@ def lambda_handler(event, context):
                 'article': article,
                 'sources': sources,
                 'recipe_count': len(top_recipes),
-                'query': query
+                'query': query,
+                'image_hotlinks': image_hotlinks,
             })
         }
         

--- a/lightweight_server.py
+++ b/lightweight_server.py
@@ -15,6 +15,7 @@ import numpy as np
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from tools import retrieval, generator
+from tools.image_utils import collect_image_hotlinks
 
 app = Flask(__name__)
 
@@ -68,11 +69,14 @@ def generate_recipe_article():
         # Extract sources
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
         
+        image_hotlinks = collect_image_hotlinks(top_recipes)
+
         return jsonify({
             'article': article,
             'sources': sources,
             'recipe_count': len(top_recipes),
-            'query': query
+            'query': query,
+            'image_hotlinks': image_hotlinks,
         })
         
     except Exception as e:

--- a/serverless_function.py
+++ b/serverless_function.py
@@ -7,6 +7,7 @@ Deploy to Vercel, Netlify Functions, or AWS Lambda.
 import json
 import os
 from tools import retrieval, generator
+from tools.image_utils import collect_image_hotlinks
 
 # Pre-computed data (loaded once per function instance)
 recipes = None
@@ -74,6 +75,8 @@ def handler(event, context=None):
         # Extract sources
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
         
+        image_hotlinks = collect_image_hotlinks(top_recipes)
+
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json'},
@@ -81,7 +84,8 @@ def handler(event, context=None):
                 'article': article,
                 'sources': sources,
                 'recipe_count': len(top_recipes),
-                'query': query
+                'query': query,
+                'image_hotlinks': image_hotlinks,
             })
         }
         

--- a/simple_server.py
+++ b/simple_server.py
@@ -12,7 +12,7 @@ import json
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from tools import airtable_sync, embeddings, vector_store, retrieval, generator
-from tools.image_utils import extract_remote_image_url
+from tools.image_utils import collect_image_hotlinks
 
 app = Flask(__name__)
 
@@ -129,17 +129,7 @@ def generate_recipe_article():
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
 
         # Surface image hotlink information so downstream systems avoid re-hosting.
-        image_hotlinks = []
-        for recipe in top_recipes:
-            image_url, airtable_field = extract_remote_image_url(recipe)
-            if not image_url:
-                continue
-            image_hotlinks.append({
-                'title': recipe.get('title', 'Untitled Recipe'),
-                'image_url': image_url,
-                'airtable_field': airtable_field,
-                'hotlink': True,
-            })
+        image_hotlinks = collect_image_hotlinks(top_recipes)
 
         return jsonify({
             'article': article,

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -1,4 +1,25 @@
-"""Recipe article generation that preserves original Airtable image links."""
+"""Recipe article generation that preserves original Airtable image links.
+
+Preparing Images for Publishing
+===============================
+
+The generator intentionally avoids downloading or re-hosting Airtable
+attachments so the resulting HTML can hotlink imagery from its original
+source. The flow works as follows:
+
+1. Each recipe section calls :func:`extract_remote_image_url` to locate the
+   Airtable field that already stores a shareable URL (for example
+   ``image_link`` or ``image_url``).
+2. The URL and field metadata are passed to :func:`build_remote_image_figure`,
+   which emits a ``<figure>`` element containing an ``<img>`` tag whose
+   ``src`` attribute points directly at the remote asset.
+3. No attempt is made to download, cache, or upload the imagery to the
+   destination site. Instead we expose an ``image_hotlinks`` payload so CMS
+   automations—such as WordPress scripts—can reuse the remote URLs when
+   setting featured images or inline content.
+4. Recipes without a valid remote URL simply omit the figure element while the
+   rest of the textual draft remains intact.
+"""
 
 from __future__ import annotations
 

--- a/vercel_function.py
+++ b/vercel_function.py
@@ -7,6 +7,7 @@ Industry standard for server-to-server AI services.
 import json
 import os
 from tools import retrieval, generator
+from tools.image_utils import collect_image_hotlinks
 
 # Pre-computed data (loaded once per function instance)
 recipes = None
@@ -77,6 +78,8 @@ def handler(request):
         # Extract sources
         sources = [recipe.get('url') for recipe in top_recipes if recipe.get('url')]
         
+        image_hotlinks = collect_image_hotlinks(top_recipes)
+
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json'},
@@ -84,7 +87,8 @@ def handler(request):
                 'article': article,
                 'sources': sources,
                 'recipe_count': len(top_recipes),
-                'query': query
+                'query': query,
+                'image_hotlinks': image_hotlinks,
             })
         }
         


### PR DESCRIPTION
## Summary
- add a shared helper that captures Airtable image hotlink metadata without downloading assets
- update every server entry point to reuse the helper and return consistent hotlink payloads
- keep article rendering unchanged so images always reference the original remote URLs

## Testing
- python -m compileall api_server.py production_server.py simple_server.py lightweight_server.py serverless_function.py lambda_function.py vercel_function.py tools/image_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68edf15712248333a810913513756736