### PR TITLE
Refine WordPress hotlinking helpers

### DIFF
--- a/WORDPRESS_HOTLINKING_GUIDE.md
+++ b/WORDPRESS_HOTLINKING_GUIDE.md
@@ -76,15 +76,13 @@ result = create_wordpress_post_with_hotlinks(
 Your existing content generation already creates hotlinked images, but you can ensure proper processing:
 
 ```python
-from tools.wordpress_integration import WordPressHotlinkIntegration
+from tools.wordpress_integration import ensure_hotlinked_images, WordPressHotlinkIntegration
 
-wp_integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
-
-# Process content to ensure hotlinking
-processed_content = wp_integration.process_content_for_hotlinking(content)
+processed_content, image_urls = ensure_hotlinked_images(content)
 
 # Validate image URLs
-for image_url in wp_integration.get_image_hotlinks_from_content(content):
+wp_integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
+for image_url in image_urls:
     if wp_integration.validate_image_url(image_url):
         print(f"✅ Image accessible: {image_url}")
     else:

--- a/scripts/wordpress_hotlink_example.py
+++ b/scripts/wordpress_hotlink_example.py
@@ -13,10 +13,13 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from tools.wordpress_integration import create_wordpress_post_with_hotlinks, validate_wordpress_hotlinking_setup
+from tools.wordpress_integration import (
+    WordPressHotlinkIntegration,
+    create_wordpress_post_with_hotlinks,
+    ensure_hotlinked_images,
+    validate_wordpress_hotlinking_setup,
+)
 from tools.generator import generate_article
-from tools.retrieval import search_recipes
-import json
 
 
 def example_wordpress_hotlinking():
@@ -94,7 +97,6 @@ def example_wordpress_hotlinking():
         print(f"Status: {result.get('status')}")
         
         # Show information about external images in the post
-        from tools.wordpress_integration import WordPressHotlinkIntegration
         wp_integration = WordPressHotlinkIntegration(WP_SITE_URL, WP_USERNAME, WP_PASSWORD)
         image_urls = wp_integration.get_image_hotlinks_from_content(article_content)
         print(f"External images in content: {len(image_urls)}")
@@ -120,12 +122,10 @@ def validate_image_urls_example():
     
     print("Validating image URLs...")
     
-    from tools.wordpress_integration import WordPressHotlinkIntegration
-    
     # Create integration instance (you'd use real credentials)
     wp_integration = WordPressHotlinkIntegration(
         wp_site_url="https://your-site.com",
-        wp_username="username", 
+        wp_username="username",
         wp_password="password"
     )
     
@@ -153,21 +153,12 @@ def process_content_example():
     print("Original content:")
     print(sample_content)
     
-    from tools.wordpress_integration import WordPressHotlinkIntegration
-    
-    wp_integration = WordPressHotlinkIntegration(
-        wp_site_url="https://your-site.com",
-        wp_username="username",
-        wp_password="password"
-    )
-    
-    processed_content = wp_integration.process_content_for_hotlinking(sample_content)
-    
+    processed_content, image_urls = ensure_hotlinked_images(sample_content)
+
     print("\nProcessed content:")
     print(processed_content)
-    
+
     # Extract image URLs
-    image_urls = wp_integration.get_image_hotlinks_from_content(processed_content)
     print(f"\nFound {len(image_urls)} image URLs:")
     for url in image_urls:
         print(f"  - {url}")

--- a/tools/wordpress_integration.py
+++ b/tools/wordpress_integration.py
@@ -1,149 +1,197 @@
-"""WordPress integration that ensures hotlinking without media library downloads.
+"""WordPress utilities that keep recipe images hotlinked instead of reuploaded.
 
-This module provides WordPress-specific functionality that:
-1. Creates blog posts with hotlinked images (no downloads)
-2. Sets featured images using external URLs
-3. Handles image validation and proxy endpoints
-4. Prevents WordPress from downloading images to media library
+The original implementation wrapped everything in a fairly stateful class that
+duplicated logic for processing HTML and creating API payloads.  The goal of
+this refactor is to make the behaviour easier to audit: we expose small helper
+functions that
+
+1. normalise every ``<img>`` element so the ``src`` attribute is left untouched,
+2. add metadata that flags the tag as a hotlink (helpful for WordPress
+   side filters), and
+3. provide a single place that performs authenticated REST calls.
+
+Because these helpers are pure functions, there is no hidden code path that can
+decide to download or mirror remote images.  The exposed convenience class is
+now a very light wrapper around those helpers so existing imports continue to
+work without modification.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import base64
+import re
+from typing import Dict, List, Tuple
+from urllib.parse import urlparse
+
 import requests
-from typing import Dict, List, Optional, Tuple
-from urllib.parse import urlparse, urljoin
-import json
 
 
+def _is_remote_url(url: str) -> bool:
+    """Return ``True`` when *url* points at an http(s) resource."""
+
+    if not isinstance(url, str):
+        return False
+
+    candidate = url.strip()
+    if not candidate:
+        return False
+
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        return False
+
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _normalise_img_tag(tag: str) -> Tuple[str, str | None]:
+    """Return a cleaned ``<img>`` element and its remote ``src`` URL.
+
+    The function keeps attribute ordering stable while appending the metadata
+    that our WordPress plugin expects.  We explicitly avoid touching the ``src``
+    attribute so WordPress will not attempt to sideload the asset.
+    """
+
+    src_match = re.search(r'src="([^"]+)"', tag, flags=re.IGNORECASE)
+    if not src_match:
+        return tag, None
+
+    src = src_match.group(1)
+    if not _is_remote_url(src):
+        # Non remote URLs (e.g. data URIs or relative paths) are returned as-is.
+        return tag, None
+
+    attributes: Dict[str, str] = {}
+    for match in re.finditer(r'(\w[\w-]*)="([^"]*)"', tag):
+        attr, value = match.groups()
+        attributes[attr.lower()] = value
+
+    # Ensure we mark the image as a hotlink without overwriting existing attrs.
+    if 'data-image-hotlink' not in attributes:
+        tag = tag.replace('<img', '<img data-image-hotlink="true"', 1)
+    if 'data-external-source' not in attributes:
+        tag = tag.replace('<img', '<img data-external-source="remote"', 1)
+    if 'loading' not in attributes:
+        tag = tag.replace('<img', '<img loading="lazy"', 1)
+    if 'decoding' not in attributes:
+        tag = tag.replace('<img', '<img decoding="async"', 1)
+
+    return tag, src
+
+
+def ensure_hotlinked_images(content: str) -> Tuple[str, List[str]]:
+    """Return *content* with hotlink metadata and the list of remote URLs."""
+
+    if not isinstance(content, str) or not content:
+        return "", []
+
+    image_urls: List[str] = []
+
+    def _rewrite(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        rewritten, src = _normalise_img_tag(tag)
+        if src:
+            image_urls.append(src)
+        return rewritten
+
+    processed = re.sub(r'<img[^>]*?>', _rewrite, content, flags=re.IGNORECASE)
+    return processed, image_urls
+
+
+def _build_auth_headers(username: str, password: str) -> Dict[str, str]:
+    """Return HTTP headers for WordPress Basic Auth."""
+
+    credentials = f"{username}:{password}".encode()
+    token = base64.b64encode(credentials).decode()
+    return {
+        "Authorization": f"Basic {token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _create_post(
+    api_base: str,
+    auth_headers: Dict[str, str],
+    *,
+    title: str,
+    content: str,
+    status: str = "draft",
+) -> Dict:
+    payload = {"title": title, "content": content, "status": status, "format": "standard"}
+    response = requests.post(f"{api_base}/posts", headers=auth_headers, json=payload)
+    if response.status_code not in (200, 201):
+        raise RuntimeError(f"Failed to create WordPress post: {response.text}")
+    return response.json()
+
+
+@dataclass(frozen=True)
 class WordPressHotlinkIntegration:
-    """WordPress integration that preserves remote image URLs without downloading."""
-    
-    def __init__(self, wp_site_url: str, wp_username: str, wp_password: str):
-        """Initialize WordPress integration with credentials."""
-        self.wp_site_url = wp_site_url.rstrip('/')
-        self.wp_username = wp_username
-        self.wp_password = wp_password
-        self.api_base = f"{self.wp_site_url}/wp-json/wp/v2"
-        
-    def _get_auth_headers(self) -> Dict[str, str]:
-        """Get authentication headers for WordPress API."""
-        import base64
-        credentials = f"{self.wp_username}:{self.wp_password}"
-        encoded_credentials = base64.b64encode(credentials.encode()).decode()
-        return {
-            'Authorization': f'Basic {encoded_credentials}',
-            'Content-Type': 'application/json'
-        }
-    
+    """Small convenience wrapper that preserves the public API from v1."""
+
+    wp_site_url: str
+    wp_username: str
+    wp_password: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "wp_site_url", self.wp_site_url.rstrip("/"))
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+    @property
+    def api_base(self) -> str:
+        return f"{self.wp_site_url}/wp-json/wp/v2"
+
+    @property
+    def _auth_headers(self) -> Dict[str, str]:
+        return _build_auth_headers(self.wp_username, self.wp_password)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def process_content_for_hotlinking(self, content: str) -> str:
+        processed, _ = ensure_hotlinked_images(content)
+        return processed
+
+    def get_image_hotlinks_from_content(self, content: str) -> List[str]:
+        _, urls = ensure_hotlinked_images(content)
+        return urls
+
     def validate_image_url(self, image_url: str) -> bool:
-        """Validate that an image URL is accessible and not blocked."""
+        if not _is_remote_url(image_url):
+            return False
         try:
-            parsed = urlparse(image_url)
-            if parsed.scheme not in ('http', 'https'):
-                return False
-                
-            # Check if URL is accessible
             response = requests.head(image_url, timeout=10, allow_redirects=True)
             return response.status_code == 200
-            
         except Exception:
             return False
-    
-    def create_post_with_hotlinked_images(
-        self, 
-        title: str, 
-        content: str, 
-        status: str = 'draft'
-    ) -> Dict:
-        """Create a WordPress post with hotlinked images in content (no media library downloads)."""
-        
-        # Process content to ensure all images use hotlinking
-        processed_content = self.process_content_for_hotlinking(content)
-        
-        # Prepare post data
-        post_data = {
-            'title': title,
-            'content': processed_content,
-            'status': status,
-            'format': 'standard'
-        }
-        
-        # Create the post
-        response = requests.post(
-            f"{self.api_base}/posts",
-            headers=self._get_auth_headers(),
-            json=post_data
-        )
-        
-        if response.status_code not in (200, 201):
-            raise Exception(f"Failed to create WordPress post: {response.text}")
-        
-        return response.json()
-    
-    
-    
-    def process_content_for_hotlinking(self, content: str) -> str:
-        """Process HTML content to ensure all images use hotlinking."""
-        import re
-        
-        # Find all img tags and ensure they use external URLs
-        def replace_img_src(match):
-            img_tag = match.group(0)
-            src_match = re.search(r'src="([^"]*)"', img_tag)
-            if src_match:
-                original_url = src_match.group(1)
-                # Keep the original URL - no processing needed for hotlinking
-                return img_tag
-            return img_tag
-        
-        # Replace img tags to ensure they're properly formatted for hotlinking
-        processed_content = re.sub(r'<img[^>]*>', replace_img_src, content)
-        
-        return processed_content
-    
-    def get_image_hotlinks_from_content(self, content: str) -> List[str]:
-        """Extract all image URLs from content for validation."""
-        import re
-        
-        img_pattern = r'<img[^>]*src="([^"]*)"[^>]*>'
-        image_urls = re.findall(img_pattern, content)
-        
-        return [url for url in image_urls if url.startswith(('http://', 'https://'))]
+
+    def create_post_with_hotlinked_images(self, title: str, content: str, *, status: str = "draft") -> Dict:
+        processed, _ = ensure_hotlinked_images(content)
+        return _create_post(self.api_base, self._auth_headers, title=title, content=processed, status=status)
 
 
 def create_wordpress_post_with_hotlinks(
     wp_site_url: str,
-    wp_username: str, 
+    wp_username: str,
     wp_password: str,
     title: str,
-    content: str
+    content: str,
+    status: str = "draft",
 ) -> Dict:
-    """Convenience function to create a WordPress post with hotlinked images in content."""
-    
-    wp_integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
-    
-    # Create the post (content processing is handled internally)
-    result = wp_integration.create_post_with_hotlinked_images(
-        title=title,
-        content=content
-    )
-    
-    return result
+    """Convenience wrapper that mirrors the class-based helper."""
+
+    integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
+    return integration.create_post_with_hotlinked_images(title=title, content=content, status=status)
 
 
 def validate_wordpress_hotlinking_setup(wp_site_url: str, wp_username: str, wp_password: str) -> bool:
-    """Validate that WordPress is properly configured for hotlinking."""
+    """Return ``True`` when credentials can query the posts endpoint."""
+
     try:
-        wp_integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
-        
-        # Test API access
-        response = requests.get(
-            f"{wp_integration.api_base}/posts",
-            headers=wp_integration._get_auth_headers(),
-            params={'per_page': 1}
-        )
-        
+        integration = WordPressHotlinkIntegration(wp_site_url, wp_username, wp_password)
+        response = requests.get(f"{integration.api_base}/posts", headers=integration._auth_headers, params={"per_page": 1})
         return response.status_code == 200
-        
     except Exception:
         return False


### PR DESCRIPTION
## Summary
- refactor the WordPress integration helpers into small pure functions that preserve remote image URLs and add consistent hotlink metadata
- expose the new `ensure_hotlinked_images` utility in the example script so the hotlink processing path is easy to follow and audit
- refresh the hotlinking guide to demonstrate the simplified helper workflow

## Testing
- python -m compileall tools/wordpress_integration.py scripts/wordpress_hotlink_example.py

------
https://chatgpt.com/codex/tasks/task_e_68ee9d6ec75c833386941627f772ad8e